### PR TITLE
Fix deprecation warning by setting SSLContext protocol

### DIFF
--- a/pyexasol/http_transport.py
+++ b/pyexasol/http_transport.py
@@ -439,7 +439,7 @@ class ExaTCPServer(socketserver.TCPServer):
             key_file.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k))
             key_file.close()
 
-            context = ssl.SSLContext()
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             context.verify_mode = ssl.CERT_NONE
             context.load_cert_chain(certfile=cert_file.name, keyfile=key_file.name)
 


### PR DESCRIPTION
Since Python 3.10, calling `ssl.SSLContext()` without specifying the protocol is deprecated (see docs). This sets the protocol to act as a server, as the socket in `server_bind()` method is being wrapped with `server_side=True` set. This means hostname checking gets disabled.