### PR TITLE
Add basic gc tests

### DIFF
--- a/test/integration/gc_test.py
+++ b/test/integration/gc_test.py
@@ -1,0 +1,44 @@
+import gc
+import pytest
+import weakref
+import pyexasol
+
+
+@pytest.mark.misc
+def test_exa_statement_gets_garbage_collected(connection):
+    # Execute statement, read some data
+    stmt = connection.execute("SELECT * FROM users")
+    stmt_ref = weakref.ref(stmt)
+    stmt.fetchmany(5)
+
+    assert stmt_ref() is not None
+
+    # Execute another statement, no more references for the first statement
+    stmt = connection.execute("SELECT * FROM payments")
+    stmt.fetchmany(5)
+
+    # collect unreferenced objects
+    gc.collect()
+
+    assert stmt_ref() is None
+
+
+@pytest.mark.misc
+def test_exa_connection_gets_garbage_collected(dsn, user, password, schema):
+    # create connection
+    con = pyexasol.connect(
+        dsn=dsn, user=user, password=password, schema=schema
+    )
+    stmt_ref = weakref.ref(con)
+
+    assert stmt_ref() is not None
+
+    # replace binding to old connection object
+    con = pyexasol.connect(
+        dsn=dsn, user=user, password=password, schema=schema
+    )
+
+    # collect unreferenced objects
+    gc.collect()
+
+    assert stmt_ref() is None


### PR DESCRIPTION
Add basic GC tests to ensure the implementation does not contain any accidental reference cycles which would prevent cleanup/garbage collection.
