### PR TITLE
Add threading event to coordinate end

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -2,6 +2,10 @@
 
 ## Summary
 
+This update improves error reporting for ``import_from_callback`` and
+``export_to_callback`` by coordinating the completion of the callback, HTTP, and SQL
+threads.
+
 ## Bugfix
 
 * #349: Modified exception reporting in `import_from_*` and `export_to_*` methods by coordinating completion of the HTTP and SQL import threads with a threading event

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -4,7 +4,7 @@
 
 ## Bugfix
 
-* #349: Modified exception reporting in `import_from_*` methods by coordinating completion of the HTTP and SQL import threads with a threading event
+* #349: Modified exception reporting in `import_from_*` and `export_to_*` methods by coordinating completion of the HTTP and SQL import threads with a threading event
 
 ## Refactoring
 

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -2,6 +2,10 @@
 
 ## Summary
 
+## Bugfix
+
+* #349: Modified exception reporting in `import_from_*` methods by coordinating completion of the HTTP and SQL import threads with a threading event
+
 ## Refactoring
 
 * #251: Simplified local runs of the integration tests to only run tests for a certificate when `--with-cert` is specified

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
     "sphinx_copybutton",
+    "sphinxcontrib.mermaid",
     "myst_parser",
     "sphinx_design",
     "exasol.toolbox.sphinx.multiversion",

--- a/doc/developer_guide.rst
+++ b/doc/developer_guide.rst
@@ -3,6 +3,11 @@
 :octicon:`tools` Developer Guide
 ================================
 
+.. toctree::
+    :maxdepth: 2
+
+    developer_guide/import_export_threading
+
 This guide explains how to develop PyExasol and run tests.
 
 Initial Setup

--- a/doc/developer_guide/import_export_threading.rst
+++ b/doc/developer_guide/import_export_threading.rst
@@ -43,7 +43,7 @@ are workers created by :meth:`ExaConnection.import_from_callback` or
 HTTP thread internals
 ---------------------
 
-The HTTP thread owns and runs the a TCP Server (``ExaTCPServer``). The server uses an
+The HTTP thread owns and runs a TCP Server (``ExaTCPServer``). The server uses an
 HTTP request handler ('`ExaHttpRequestHandler``) to move data between Exasol and the pipe.
 
 .. mermaid::

--- a/doc/developer_guide/import_export_threading.rst
+++ b/doc/developer_guide/import_export_threading.rst
@@ -40,11 +40,11 @@ are workers created by :meth:`ExaConnection.import_from_callback` or
         sql --> |"executes IMPORT or EXPORT"| db
         sql -.-> |"uses address and terminates on failure"| http
 
-HTTP thread internals
+HTTP Thread Internals
 ---------------------
 
 The HTTP thread owns and runs a TCP Server (``ExaTCPServer``). The server uses an
-HTTP request handler ('`ExaHttpRequestHandler``) to move data between Exasol and the pipe.
+HTTP request handler (``ExaHttpRequestHandler``) to move data between Exasol and the pipe.
 
 .. mermaid::
 
@@ -75,7 +75,7 @@ The pipe separates the callback from the network transport. This lets the
 callback work with a file-like binary stream without needing to know about the
 socket or the HTTP request.
 
-Data flow
+Data Flow
 ---------
 
 The direction through the HTTP thread depends on the operation:
@@ -92,7 +92,7 @@ thread. The coordinator waits for the workers, joins the HTTP thread first, and
 then joins the SQL thread so that a SQL failure can stop the HTTP worker before
 cleanup waits for it.
 
-Understanding failures
+Understanding Failures
 ----------------------
 
 An exception can originate in the callback, the HTTP transport, or the SQL

--- a/doc/developer_guide/import_export_threading.rst
+++ b/doc/developer_guide/import_export_threading.rst
@@ -1,0 +1,113 @@
+Import and Export Threading
+===========================
+
+The :doc:`user guide's import and export overview
+<../user_guide/exploring_features/import_and_export/index>` describes the
+public behavior and links to further usage details. This page complements it
+with an implementation-oriented view of the threads and transport components
+behind callback-based ``IMPORT`` and ``EXPORT`` operations. The diagrams make
+the ownership, data flow, and error-propagation relationships easier to trace
+when developing or debugging PyExasol.
+
+The callback variants of ``IMPORT`` and ``EXPORT`` use three cooperating threads.
+The calling thread runs the user callback, while an HTTP thread transfers data
+and a SQL thread executes the database statement. The HTTP thread and SQL thread
+are workers created by :meth:`ExaConnection.import_from_callback` or
+:meth:`ExaConnection.export_to_callback`.
+
+.. mermaid::
+
+    flowchart TD
+        subgraph callback_group["Callback"]
+            callback["Calling thread"]
+            pipe["OS pipe"]
+
+            callback <--> |"reads or writes data"| pipe
+        end
+
+        subgraph http_group["HTTP thread"]
+            http["ExaHttpThread"]
+        end
+
+        subgraph sql_group["SQL thread"]
+            sql["ExaSQLImportThread or<br/>ExaSQLExportThread"]
+        end
+
+        db[("Exasol database")]
+
+        pipe <--> http
+        http <--> |"HTTP(S) transport"| db
+        sql --> |"executes IMPORT or EXPORT"| db
+        sql -.-> |"uses address and terminates on failure"| http
+
+HTTP thread internals
+---------------------
+
+The HTTP thread owns and runs the a TCP Server (``ExaTCPServer``). The server uses an
+HTTP request handler ('`ExaHttpRequestHandler``) to move data between Exasol and the pipe.
+
+.. mermaid::
+
+    flowchart TD
+        subgraph http_group["HTTP thread"]
+            http["ExaHttpThread"] --> |"owns and runs"| server["ExaTCPServer"]
+            server --> handler["ExaHttpRequestHandler"]
+        end
+
+        handler <--> pipe["OS pipe"]
+        handler <--> |"HTTP(S) request"| db[("Exasol database")]
+
+Responsibilities
+----------------
+
+* **Calling thread:** Starts the workers and runs the user callback. For an
+  ``IMPORT``, the callback writes data to the pipe. For an ``EXPORT``, it reads
+  data from the pipe.
+* **HTTP thread:** Owns a TCP server (``ExaTCPServer``) and runs its request loop. The
+  server passes the request to a request handler (``ExaHttpRequestHandler``), which moves
+  the streamed data through the pipe.
+* **SQL thread:** Builds and executes the ``IMPORT`` or ``EXPORT`` statement. The
+  statement contains the address exposed by the TCP server, so Exasol can
+  connect to the HTTP thread. The SQL thread also keeps a reference to the HTTP
+  thread and terminates it when the SQL operation fails.
+
+The pipe separates the callback from the network transport. This lets the
+callback work with a file-like binary stream without needing to know about the
+socket or the HTTP request.
+
+Data flow
+---------
+
+The direction through the HTTP thread depends on the operation:
+
+* For ``EXPORT``, Exasol sends an HTTP ``PUT`` request to the TCP server.
+  The request handler writes the received data to the pipe, and the callback
+  reads that data from the pipe.
+* For ``IMPORT``, Exasol sends an HTTP ``GET`` request to the TCP server.
+  The callback writes data to the pipe, while the request handler reads it and
+  sends it to Exasol.
+
+In both cases, the SQL thread runs concurrently with the callback and the HTTP
+thread. The coordinator waits for the workers, joins the HTTP thread first, and
+then joins the SQL thread so that a SQL failure can stop the HTTP worker before
+cleanup waits for it.
+
+Understanding failures
+----------------------
+
+An exception can originate in the callback, the HTTP transport, or the SQL
+operation. Since the components share a data path and depend on one another,
+one failure can cause a secondary failure elsewhere. The callback API collects
+the exceptions observed during cleanup in ``ExaImportError`` or
+``ExaExportError``.
+
+For example, if ``ExaTCPServer.handle_request()`` raises a transport exception,
+``ExaHttpThread.run()`` stores it in ``http_thread.exc``. The SQL operation may
+also fail because its ``IMPORT`` or ``EXPORT`` transport was interrupted. Both
+failures can therefore appear in the aggregated exception. Conversely, if the
+SQL thread fails first, it terminates the HTTP thread; the HTTP thread may then
+exit without an independent exception.
+
+For the public behavior and callback variants, see :doc:`the user guide
+<../user_guide/exploring_features/import_and_export/index>` and
+:doc:`HTTP Transport <../user_guide/exploring_features/import_and_export/http_transport>`.

--- a/pyexasol/connection.py
+++ b/pyexasol/connection.py
@@ -995,7 +995,13 @@ class ExaConnection:
             self.options["encryption"],
             thread_event=thread_event,
         )
-        sql_thread = ExaSQLImportThread(self, compression, table, import_params)
+        sql_thread = ExaSQLImportThread(
+            self,
+            compression,
+            table,
+            import_params,
+            thread_event=thread_event,
+        )
 
         try:
             http_thread.start()
@@ -1006,10 +1012,17 @@ class ExaConnection:
             with http_thread.write_pipe as pipe:
                 result = callback(pipe, src, **callback_params)
 
+            # The callback has finished writing. Allow the HTTP handler to send the
+            # final chunk and finish the request.
+            http_thread.server.can_finish_get.set()
+
+            # Either worker may finish first. Wake up as soon as one reports
+            # completion so errors can be observed without waiting on the
+            # other connection indefinitely.
             thread_event.wait()
 
-            http_thread.raise_with_exception()
-            sql_thread.raise_with_exception()
+            http_thread.join_with_exc()
+            sql_thread.join_with_exc()
 
             return result
 

--- a/pyexasol/connection.py
+++ b/pyexasol/connection.py
@@ -987,11 +987,13 @@ class ExaConnection:
             False if ("format" in import_params) else self.options["compression"]
         )
 
+        thread_event = threading.Event()
         http_thread = ExaHttpThread(
             self.ws_ipaddr,  # type: ignore
             self.ws_port,  # type: ignore
             compression,
             self.options["encryption"],
+            thread_event=thread_event,
         )
         sql_thread = ExaSQLImportThread(self, compression, table, import_params)
 
@@ -1004,8 +1006,13 @@ class ExaConnection:
             with http_thread.write_pipe as pipe:
                 result = callback(pipe, src, **callback_params)
 
-            http_thread.join_with_exc()
-            sql_thread.join_with_exc()
+            http_thread.join()
+            sql_thread.join()
+
+            thread_event.wait()
+
+            http_thread.raise_with_exception()
+            sql_thread.raise_with_exception()
 
             return result
 

--- a/pyexasol/connection.py
+++ b/pyexasol/connection.py
@@ -1006,9 +1006,6 @@ class ExaConnection:
             with http_thread.write_pipe as pipe:
                 result = callback(pipe, src, **callback_params)
 
-            http_thread.join()
-            sql_thread.join()
-
             thread_event.wait()
 
             http_thread.raise_with_exception()

--- a/pyexasol/connection.py
+++ b/pyexasol/connection.py
@@ -933,7 +933,7 @@ class ExaConnection:
             with http_thread.read_pipe as pipe:
                 result = callback(pipe, dst, **callback_params)
 
-            # The callback has finished writing. Allow the HTTP handler to send the
+            # The callback has finished. Allow the HTTP handler to send the
             # final chunk and finish the request.
             http_thread.server.can_finish_get.set()
 

--- a/pyexasol/connection.py
+++ b/pyexasol/connection.py
@@ -906,20 +906,22 @@ class ExaConnection:
             False if ("format" in export_params) else self.options["compression"]
         )
 
-        thread_event = threading.Event()
+        # Set when either worker finishes, successfully or exceptionally. It
+        # wakes the coordinator but does not terminate the other worker.
+        worker_finished_event = threading.Event()
         http_thread = ExaHttpThread(
             ipaddr=self.ws_ipaddr,  # type: ignore
             port=self.ws_port,  # type: ignore
             compression=compression,
             encryption=self.options["encryption"],
-            thread_event=thread_event,
+            worker_finished_event=worker_finished_event,
         )
         sql_thread = ExaSQLExportThread(
             connection=self,
             compression=compression,
             query_or_table=query_or_table,
             export_params=export_params,
-            thread_event=thread_event,
+            worker_finished_event=worker_finished_event,
         )
 
         try:
@@ -938,8 +940,11 @@ class ExaConnection:
             # Either worker may finish first. Wake up as soon as one reports
             # completion so errors can be observed without waiting on the
             # other connection indefinitely.
-            thread_event.wait()
+            worker_finished_event.wait()
 
+            # Join HTTP first: an SQL failure terminates HTTP, while HTTP does
+            # not terminate SQL directly. The order prevents waiting on HTTP
+            # before the SQL worker has had a chance to stop it.
             http_thread.join_with_exc()
             sql_thread.join_with_exc()
 
@@ -1002,20 +1007,22 @@ class ExaConnection:
             False if ("format" in import_params) else self.options["compression"]
         )
 
-        thread_event = threading.Event()
+        # Set when either worker finishes, successfully or exceptionally. It
+        # wakes the coordinator but does not terminate the other worker.
+        worker_finished_event = threading.Event()
         http_thread = ExaHttpThread(
             ipaddr=self.ws_ipaddr,  # type: ignore
             port=self.ws_port,  # type: ignore
             compression=compression,
             encryption=self.options["encryption"],
-            thread_event=thread_event,
+            worker_finished_event=worker_finished_event,
         )
         sql_thread = ExaSQLImportThread(
             connection=self,
             compression=compression,
             table=table,
             import_params=import_params,
-            thread_event=thread_event,
+            worker_finished_event=worker_finished_event,
         )
 
         try:
@@ -1034,8 +1041,11 @@ class ExaConnection:
             # Either worker may finish first. Wake up as soon as one reports
             # completion so errors can be observed without waiting on the
             # other connection indefinitely.
-            thread_event.wait()
+            worker_finished_event.wait()
 
+            # Join HTTP first: an SQL failure terminates HTTP, while HTTP does
+            # not terminate SQL directly. The order prevents waiting on HTTP
+            # before the SQL worker has had a chance to stop it.
             http_thread.join_with_exc()
             sql_thread.join_with_exc()
 

--- a/pyexasol/connection.py
+++ b/pyexasol/connection.py
@@ -906,14 +906,20 @@ class ExaConnection:
             False if ("format" in export_params) else self.options["compression"]
         )
 
+        thread_event = threading.Event()
         http_thread = ExaHttpThread(
-            self.ws_ipaddr,  # type: ignore
-            self.ws_port,  # type: ignore
-            compression,
-            self.options["encryption"],
+            ipaddr=self.ws_ipaddr,  # type: ignore
+            port=self.ws_port,  # type: ignore
+            compression=compression,
+            encryption=self.options["encryption"],
+            thread_event=thread_event,
         )
         sql_thread = ExaSQLExportThread(
-            self, compression, query_or_table, export_params
+            connection=self,
+            compression=compression,
+            query_or_table=query_or_table,
+            export_params=export_params,
+            thread_event=thread_event,
         )
 
         try:
@@ -924,6 +930,15 @@ class ExaConnection:
 
             with http_thread.read_pipe as pipe:
                 result = callback(pipe, dst, **callback_params)
+
+            # The callback has finished writing. Allow the HTTP handler to send the
+            # final chunk and finish the request.
+            http_thread.server.can_finish_get.set()
+
+            # Either worker may finish first. Wake up as soon as one reports
+            # completion so errors can be observed without waiting on the
+            # other connection indefinitely.
+            thread_event.wait()
 
             http_thread.join_with_exc()
             sql_thread.join_with_exc()
@@ -989,17 +1004,17 @@ class ExaConnection:
 
         thread_event = threading.Event()
         http_thread = ExaHttpThread(
-            self.ws_ipaddr,  # type: ignore
-            self.ws_port,  # type: ignore
-            compression,
-            self.options["encryption"],
+            ipaddr=self.ws_ipaddr,  # type: ignore
+            port=self.ws_port,  # type: ignore
+            compression=compression,
+            encryption=self.options["encryption"],
             thread_event=thread_event,
         )
         sql_thread = ExaSQLImportThread(
-            self,
-            compression,
-            table,
-            import_params,
+            connection=self,
+            compression=compression,
+            table=table,
+            import_params=import_params,
             thread_event=thread_event,
         )
 

--- a/pyexasol/connection.py
+++ b/pyexasol/connection.py
@@ -933,10 +933,6 @@ class ExaConnection:
             with http_thread.read_pipe as pipe:
                 result = callback(pipe, dst, **callback_params)
 
-            # The callback has finished. Allow the HTTP handler to send the
-            # final chunk and finish the request.
-            http_thread.server.can_finish_get.set()
-
             # Either worker may finish first. Wake up as soon as one reports
             # completion so errors can be observed without waiting on the
             # other connection indefinitely.

--- a/pyexasol/http_transport.py
+++ b/pyexasol/http_transport.py
@@ -302,7 +302,7 @@ class ExaSQLThread(threading.Thread):
         self,
         connection: ExaConnection,
         compression: bool,
-        thread_event: threading.Event | None = None,
+        worker_finished_event: threading.Event | None = None,
     ):
         self.connection = connection
         self.compression = compression
@@ -311,7 +311,7 @@ class ExaSQLThread(threading.Thread):
         self.http_thread = None
         self.exa_address_list: list[str] = []
         self.exc = None
-        self.thread_event = thread_event
+        self.worker_finished_event = worker_finished_event
 
         super().__init__()
 
@@ -332,8 +332,8 @@ class ExaSQLThread(threading.Thread):
             if self.http_thread:
                 self.http_thread.terminate()
         finally:
-            if self.thread_event:
-                self.thread_event.set()
+            if self.worker_finished_event:
+                self.worker_finished_event.set()
 
     def run_sql(self):
         pass
@@ -356,9 +356,11 @@ class ExaSQLExportThread(ExaSQLThread):
         compression: bool,
         query_or_table,
         export_params: dict,
-        thread_event: threading.Event | None = None,
+        worker_finished_event: threading.Event | None = None,
     ):
-        super().__init__(connection, compression, thread_event=thread_event)
+        super().__init__(
+            connection, compression, worker_finished_event=worker_finished_event
+        )
 
         self.query_or_table = query_or_table
         self.params = export_params
@@ -399,9 +401,11 @@ class ExaSQLImportThread(ExaSQLThread):
         compression: bool,
         table: str,
         import_params: dict,
-        thread_event: threading.Event | None = None,
+        worker_finished_event: threading.Event | None = None,
     ):
-        super().__init__(connection, compression, thread_event=thread_event)
+        super().__init__(
+            connection, compression, worker_finished_event=worker_finished_event
+        )
 
         self.table = table
         self.params = import_params
@@ -430,7 +434,7 @@ class ExaHttpThread(threading.Thread):
         port: int,
         compression: bool,
         encryption: bool,
-        thread_event: threading.Event | None = None,
+        worker_finished_event: threading.Event | None = None,
     ):
         self.server = ExaTCPServer(
             (ipaddr, port),
@@ -441,7 +445,7 @@ class ExaHttpThread(threading.Thread):
 
         self.read_pipe = self.server.read_pipe
         self.write_pipe = self.server.write_pipe
-        self.thread_event = thread_event
+        self.worker_finished_event = worker_finished_event
 
         self.exc = None
 
@@ -464,8 +468,8 @@ class ExaHttpThread(threading.Thread):
             self.exc = e
         finally:
             self.server.server_close()
-            if self.thread_event is not None:
-                self.thread_event.set()
+            if self.worker_finished_event is not None:
+                self.worker_finished_event.set()
 
     def join(self, timeout=None):
         self.server.can_finish_get.set()

--- a/pyexasol/http_transport.py
+++ b/pyexasol/http_transport.py
@@ -298,7 +298,12 @@ class ExaSQLThread(threading.Thread):
     Thread class which re-throws any Exception to parent thread
     """
 
-    def __init__(self, connection: ExaConnection, compression: bool):
+    def __init__(
+        self,
+        connection: ExaConnection,
+        compression: bool,
+        thread_event: threading.Event | None = None,
+    ):
         self.connection = connection
         self.compression = compression
 
@@ -306,6 +311,7 @@ class ExaSQLThread(threading.Thread):
         self.http_thread = None
         self.exa_address_list: list[str] = []
         self.exc = None
+        self.thread_event = thread_event
 
         super().__init__()
 
@@ -325,13 +331,18 @@ class ExaSQLThread(threading.Thread):
             # In case of SQL error stop HTTP server, close pipes and interrupt I/O in callback function
             if self.http_thread:
                 self.http_thread.terminate()
+        finally:
+            if self.thread_event:
+                self.thread_event.set()
 
     def run_sql(self):
         pass
 
     def join_with_exc(self, *args):
         super().join(*args)
+        self.raise_with_exception()
 
+    def raise_with_exception(self):
         if self.exc:
             raise self.exc
 
@@ -390,8 +401,9 @@ class ExaSQLImportThread(ExaSQLThread):
         compression: bool,
         table: str,
         import_params: dict,
+        thread_event: threading.Event | None = None,
     ):
-        super().__init__(connection, compression)
+        super().__init__(connection, compression, thread_event=thread_event)
 
         self.table = table
         self.params = import_params
@@ -414,7 +426,14 @@ class ExaHttpThread(threading.Thread):
     - https://pythonforthelab.com/blog/differences-between-multiprocessing-windows-and-linux/
     """
 
-    def __init__(self, ipaddr: str, port: int, compression: bool, encryption: bool):
+    def __init__(
+        self,
+        ipaddr: str,
+        port: int,
+        compression: bool,
+        encryption: bool,
+        thread_event: threading.Event | None = None,
+    ):
         self.server = ExaTCPServer(
             (ipaddr, port),
             ExaHttpRequestHandler,
@@ -424,6 +443,7 @@ class ExaHttpThread(threading.Thread):
 
         self.read_pipe = self.server.read_pipe
         self.write_pipe = self.server.write_pipe
+        self.thread_event = thread_event
 
         self.exc = None
 
@@ -446,6 +466,8 @@ class ExaHttpThread(threading.Thread):
             self.exc = e
         finally:
             self.server.server_close()
+            if self.thread_event is not None:
+                self.thread_event.set()
 
     def join(self, timeout=None):
         self.server.can_finish_get.set()
@@ -454,6 +476,10 @@ class ExaHttpThread(threading.Thread):
     def join_with_exc(self):
         self.join()
 
+        if self.exc:
+            raise self.exc
+
+    def raise_with_exception(self):
         if self.exc:
             raise self.exc
 

--- a/pyexasol/http_transport.py
+++ b/pyexasol/http_transport.py
@@ -340,9 +340,6 @@ class ExaSQLThread(threading.Thread):
 
     def join_with_exc(self, *args):
         super().join(*args)
-        self.raise_with_exception()
-
-    def raise_with_exception(self):
         if self.exc:
             raise self.exc
 
@@ -476,10 +473,6 @@ class ExaHttpThread(threading.Thread):
     def join_with_exc(self):
         self.join()
 
-        if self.exc:
-            raise self.exc
-
-    def raise_with_exception(self):
         if self.exc:
             raise self.exc
 

--- a/pyexasol/http_transport.py
+++ b/pyexasol/http_transport.py
@@ -356,8 +356,9 @@ class ExaSQLExportThread(ExaSQLThread):
         compression: bool,
         query_or_table,
         export_params: dict,
+        thread_event: threading.Event | None = None,
     ):
-        super().__init__(connection, compression)
+        super().__init__(connection, compression, thread_event=thread_event)
 
         self.query_or_table = query_or_table
         self.params = export_params

--- a/test/integration/import_and_export/conftest.py
+++ b/test/integration/import_and_export/conftest.py
@@ -1,12 +1,16 @@
 import copy
+from contextlib import contextmanager
 from datetime import datetime
 from inspect import cleandoc
 from test.integration.import_and_export.data_sample import (
     DATETIME_STR_FORMAT,
     DataSample,
 )
+from unittest.mock import patch
 
 import pytest
+
+from pyexasol.http_transport import ExaHttpThread
 
 ALL_COLUMNS = [
     "FIRST_NAME",
@@ -29,6 +33,50 @@ def table_name():
 @pytest.fixture(scope="session", autouse=True)
 def faker_seed():
     return 12345
+
+
+class ThreadHelper:
+    """Proxy exposing a worker thread created inside the context manager."""
+
+    def __init__(self):
+        self.instance = None
+
+    def __getattr__(self, attribute):
+        if self.instance is None:
+            raise AssertionError("Thread was not created")
+        return getattr(self.instance, attribute)
+
+
+@pytest.fixture
+def capture_callback_threads():
+    """Return a context manager for capturing callback worker threads."""
+
+    @contextmanager
+    def capture_threads(sql_thread_class):
+        http_thread = ThreadHelper()
+        sql_thread = ThreadHelper()
+
+        def create_http_thread(*args, **kwargs):
+            http_thread.instance = ExaHttpThread(*args, **kwargs)
+            return http_thread.instance
+
+        def create_sql_thread(*args, **kwargs):
+            sql_thread.instance = sql_thread_class(*args, **kwargs)
+            return sql_thread.instance
+
+        with (
+            patch(
+                "pyexasol.connection.ExaHttpThread",
+                side_effect=create_http_thread,
+            ),
+            patch(
+                "pyexasol.connection." + sql_thread_class.__name__,
+                side_effect=create_sql_thread,
+            ),
+        ):
+            yield http_thread, sql_thread
+
+    return capture_threads
 
 
 @pytest.fixture

--- a/test/integration/import_and_export/export_to_callback_test.py
+++ b/test/integration/import_and_export/export_to_callback_test.py
@@ -110,6 +110,12 @@ class TestExportToCallbackExceptions:
     def test_export_callback_has_exception(
         connection, empty_table, capture_callback_threads
     ):
+        """
+        The export callback running in the calling thread raises a ``ValueError``:
+          - The callback fails before it can consume any exported data.
+          - The HTTP thread is stopped during cleanup and does not raise an exception.
+          - The SQL thread does not observe a separate failure.
+        """
         error = ValueError("Error from callback")
 
         def raise_error(pipe, dst, **kwargs):
@@ -133,6 +139,15 @@ class TestExportToCallbackExceptions:
     def test_closed_ws_connection(
         connection_factory, empty_table, export_cb, capture_callback_threads
     ):
+        """
+        The callback closes the WebSocket while the SQL thread and the HTTP thread
+        are using it:
+          - The calling thread fails while reading from the callback pipe.
+          - The SQL thread fails because its database request loses the WebSocket
+            transport.
+          - The SQL thread terminates the HTTP thread, and the HTTP thread does not
+            raise an exception.
+        """
         new_connection = connection_factory()
 
         def export_cb_with_close(pipe, dst, **kwargs):
@@ -166,6 +181,17 @@ class TestExportToCallbackExceptions:
         export_cb,
         capture_callback_threads,
     ):
+        """
+        The ``ExaHttpRequestHandler`` running through the ``ExaTCPServer`` (owned by
+        the HTTP thread) raises ``BrokenPipeError`` while writing the final chunk:
+          - The HTTP thread (``ExaHttpThread``) handles the failed transport and
+            closes the HTTP response.
+          - The SQL thread is executing the EXPORT that depends on that response,
+            so it records an ``ExaQueryError``.
+          - The callback is not the failing component and does not raise an
+            exception. Only the SQL-thread exception is expected.
+        """
+
         def write_final_chunk_with_exception(_handler):
             raise BrokenPipeError("Broken pipe in http_thread")
 
@@ -196,6 +222,14 @@ class TestExportToCallbackExceptions:
     def test_http_thread_captures_transport_exception(
         connection, output_filepath, empty_table, export_cb, capture_callback_threads
     ):
+        """
+        The TCP server (owned by the HTTP thread) raises a ``BrokenPipeError``:
+          - The HTTP thread captures the exception raised by its TCP server.
+          - Because the TCP server can no longer carry the exported data, the
+            concurrently running SQL thread's EXPORT receives a transport failure
+            and raises an ``ExaQueryError``.
+          - The callback only consumes data and does not raise an exception.
+        """
         error = BrokenPipeError("Broken pipe in http_thread")
 
         def handle_request_with_exception(_server):
@@ -232,6 +266,14 @@ class TestExportToCallbackExceptions:
         fill_table,
         capture_callback_threads,
     ):
+        """
+        The SQL thread raises a database-license ``ExaQueryError`` before EXPORT
+        can deliver rows:
+          - The SQL thread terminates the HTTP thread and closes the callback pipe.
+          - The callback then attempts to read from that pipe and raises a
+            ``ValueError``.
+        """
+
         def streaming_export_cb(pipe, dst, **kwargs):
             with dst.open("wb") as output_file:
                 while chunk := pipe.read(8192):
@@ -268,6 +310,13 @@ class TestExportToCallbackExceptions:
     def test_http_thread_has_exception(
         connection, output_filepath, empty_table, export_cb
     ):
+        """
+        The HTTP thread raises a ``BrokenPipeError`` when the coordinator:
+          - The calling thread receives the HTTP-thread exception after the
+            callback has finished.
+          - The SQL thread is not executing a failing query and does not raise an
+            exception.
+        """
         with patch("pyexasol.connection.ExaHttpThread.join_with_exc") as mock:
             mock.side_effect = BrokenPipeError("Broken pipe in http_thread")
 
@@ -283,6 +332,12 @@ class TestExportToCallbackExceptions:
 
     @staticmethod
     def test_sql_thread_has_exception(connection, output_filepath, export_cb):
+        """
+        The SQL thread executes the EXPORT query, so it detects the missing table
+        and raises an ``ExaQueryError``:
+          - The callback only consumes output and does not raise an exception.
+          - The HTTP thread only transports the output and does not report an exception.
+        """
         with pytest.raises(ExaExportError, match="1 sub-exception") as ex:
             connection.export_to_callback(
                 callback=export_cb, dst=output_filepath, query_or_table="DOES_NOT_EXIST"
@@ -294,13 +349,14 @@ class TestExportToCallbackExceptions:
 
     @staticmethod
     def test_abort_query(
-        connection, output_filepath, empty_table, export_cb, capture_callback_threads
+        connection, output_filepath, fill_table, export_cb, capture_callback_threads
     ):
         """
-        Due to a race condition, it's difficult to create a test with
-        connection.abort_query() that ensures that an exception would be raised.
-        Thus, we mock that here. Still, there is a race condition whether 1 or 2
-        exceptions are raised.
+        The SQL thread raises an ``ExaQueryError`` because the EXPORT query is
+        aborted:
+          - The SQL thread terminates the HTTP thread.
+          - The callback pipe is closed while the callback is still active, so the
+            HTTP/callback path contributes a second exception.
         """
         with patch("pyexasol.connection.ExaSQLExportThread.run_sql") as mock:
             mock.side_effect = ExaQueryError(
@@ -318,14 +374,12 @@ class TestExportToCallbackExceptions:
                     connection.export_to_callback(
                         callback=export_cb,
                         dst=output_filepath,
-                        query_or_table=empty_table,
+                        query_or_table=fill_table,
                     )
 
-        query_error_loc = 0
-        if len(ex.value.exceptions) == 2:
-            query_error_loc = 1
+        assert len(ex.value.exceptions) == 2
 
-        selected_exception = ex.value.exceptions[query_error_loc]
+        selected_exception = ex.value.exceptions[1]
         assert isinstance(selected_exception, ExaQueryError)
         assert "Client requested execution abort." in selected_exception.message
         assert not http_thread.is_alive()
@@ -335,6 +389,14 @@ class TestExportToCallbackExceptions:
     def test_export_callback_and_sql_have_different_exceptions(
         connection, capture_callback_threads
     ):
+        """
+        The callback in the calling thread raises a ``ValueError`` before it can
+        consume the export stream. The SQL thread independently executes the
+        EXPORT:
+          - The SQL thread reports the missing-table ``ExaQueryError`` because it
+            is the only component executing the query.
+          - The HTTP thread is terminated during cleanup and does not raise an exception.
+        """
         error = ValueError("Error from callback")
 
         def export_cb(pipe, dst, **kwargs):

--- a/test/integration/import_and_export/export_to_callback_test.py
+++ b/test/integration/import_and_export/export_to_callback_test.py
@@ -131,7 +131,7 @@ class TestExportToCallbackExceptions:
 
     @staticmethod
     def test_closed_ws_connection(
-        connection_factory, connection, empty_table, export_cb, capture_callback_threads
+        connection_factory, empty_table, export_cb, capture_callback_threads
     ):
         new_connection = connection_factory()
 

--- a/test/integration/import_and_export/export_to_callback_test.py
+++ b/test/integration/import_and_export/export_to_callback_test.py
@@ -112,7 +112,7 @@ class TestExportToCallbackExceptions:
     ):
         error = ValueError("Error from callback")
 
-        def export_cb(pipe, dst, **kwargs):
+        def raise_error(pipe, dst, **kwargs):
             raise error
 
         with capture_callback_threads(ExaSQLExportThread) as (
@@ -121,7 +121,7 @@ class TestExportToCallbackExceptions:
         ):
             with pytest.raises(ExaExportError, match="1 sub-exception") as ex:
                 connection.export_to_callback(
-                    callback=export_cb, dst=None, query_or_table=empty_table
+                    callback=raise_error, dst=None, query_or_table=empty_table
                 )
 
         assert len(ex.value.exceptions) == 1

--- a/test/integration/import_and_export/export_to_callback_test.py
+++ b/test/integration/import_and_export/export_to_callback_test.py
@@ -1,10 +1,18 @@
+import time
 from unittest.mock import patch
 
 import pytest
 
 from pyexasol.exceptions import (
+    ExaCommunicationError,
     ExaExportError,
     ExaQueryError,
+    ExaRuntimeError,
+)
+from pyexasol.http_transport import (
+    ExaHttpRequestHandler,
+    ExaSQLExportThread,
+    ExaTCPServer,
 )
 
 
@@ -99,18 +107,159 @@ class TestExportGeneral:
 @pytest.mark.exceptions
 class TestExportToCallbackExceptions:
     @staticmethod
-    def test_export_callback_has_exception(connection, empty_table):
+    def test_export_callback_has_exception(
+        connection, empty_table, capture_callback_threads
+    ):
         error = ValueError("Error from callback")
 
         def export_cb(pipe, dst, **kwargs):
             raise error
 
-        with pytest.raises(ExaExportError, match="1 sub-exception") as ex:
-            connection.export_to_callback(
-                callback=export_cb, dst=None, query_or_table=empty_table
-            )
+        with capture_callback_threads(ExaSQLExportThread) as (
+            http_thread,
+            sql_thread,
+        ):
+            with pytest.raises(ExaExportError, match="1 sub-exception") as ex:
+                connection.export_to_callback(
+                    callback=export_cb, dst=None, query_or_table=empty_table
+                )
 
-        assert ex.value.exceptions == [error]
+        assert len(ex.value.exceptions) == 1
+        assert ex.value.exceptions[0] == error
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
+
+    @staticmethod
+    def test_closed_ws_connection(
+        connection_factory, connection, empty_table, export_cb, capture_callback_threads
+    ):
+        new_connection = connection_factory()
+
+        def export_cb_with_close(pipe, dst, **kwargs):
+            new_connection.close(disconnect=False)
+            time.sleep(2)
+            export_cb(pipe, dst, **kwargs)
+
+        with capture_callback_threads(ExaSQLExportThread) as (
+            http_thread,
+            sql_thread,
+        ):
+            with pytest.raises(ExaExportError) as ex:
+                new_connection.export_to_callback(
+                    export_cb_with_close, None, empty_table
+                )
+
+        assert len(ex.value.exceptions) == 2
+        assert type(ex.value.exceptions[1]) in (
+            ExaCommunicationError,
+            ExaRuntimeError,
+            OSError,
+        )
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
+
+    @staticmethod
+    def test_http_handler_failure_propagates_to_sql_thread(
+        connection,
+        output_filepath,
+        fill_table,
+        export_cb,
+        capture_callback_threads,
+    ):
+        error = BrokenPipeError("Broken pipe in http_thread")
+
+        def write_final_chunk_with_exception(_handler):
+            raise error
+
+        with patch.object(
+            ExaHttpRequestHandler,
+            "write_final_chunk",
+            autospec=True,
+            side_effect=write_final_chunk_with_exception,
+        ):
+            with capture_callback_threads(ExaSQLExportThread) as (
+                http_thread,
+                sql_thread,
+            ):
+                with pytest.raises(ExaExportError, match="1 sub-exception") as ex:
+                    connection.export_to_callback(
+                        callback=export_cb,
+                        dst=output_filepath,
+                        query_or_table=fill_table,
+                    )
+
+        assert len(ex.value.exceptions) == 1
+        assert isinstance(ex.value.exceptions[0], ExaQueryError)
+        assert isinstance(sql_thread.exc, ExaQueryError)
+        assert not sql_thread.is_alive()
+        assert not http_thread.is_alive()
+
+    @staticmethod
+    def test_http_thread_captures_transport_exception(
+        connection, output_filepath, empty_table, export_cb, capture_callback_threads
+    ):
+        error = BrokenPipeError("Broken pipe in http_thread")
+
+        def handle_request_with_exception(_server):
+            raise error
+
+        with patch.object(
+            ExaTCPServer,
+            "handle_request",
+            autospec=True,
+            side_effect=handle_request_with_exception,
+        ):
+            with capture_callback_threads(ExaSQLExportThread) as (
+                http_thread,
+                sql_thread,
+            ):
+                with pytest.raises(ExaExportError, match="2 sub-exceptions") as ex:
+                    connection.export_to_callback(
+                        callback=export_cb,
+                        dst=output_filepath,
+                        query_or_table=empty_table,
+                    )
+
+        assert len(ex.value.exceptions) == 2
+        assert isinstance(ex.value.exceptions[0], BrokenPipeError)
+        assert isinstance(ex.value.exceptions[1], ExaQueryError)
+        assert http_thread.exc is error
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
+
+    @staticmethod
+    def test_sql_thread_has_outdated_database_license(
+        connection,
+        output_filepath,
+        empty_table,
+        export_cb,
+        capture_callback_threads,
+    ):
+        license_error = ExaQueryError(
+            connection=connection,
+            query="EXPORT ...",
+            code="42000",
+            message="Database license is out of date.",
+        )
+
+        with patch.object(connection, "execute", side_effect=license_error):
+            with capture_callback_threads(ExaSQLExportThread) as (
+                http_thread,
+                sql_thread,
+            ):
+                with pytest.raises(ExaExportError, match="1 sub-exception") as ex:
+                    connection.export_to_callback(
+                        callback=export_cb,
+                        dst=output_filepath,
+                        query_or_table=empty_table,
+                    )
+
+        assert len(ex.value.exceptions) == 1
+        assert ex.value.exceptions[0] is license_error
+        assert sql_thread.exc is license_error
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
+        assert http_thread.server.socket.fileno() == -1
 
     @staticmethod
     def test_http_thread_has_exception(
@@ -141,7 +290,9 @@ class TestExportToCallbackExceptions:
         assert "object DOES_NOT_EXIST not found" in ex.value.exceptions[0].message
 
     @staticmethod
-    def test_abort_query(connection, output_filepath, empty_table, export_cb):
+    def test_abort_query(
+        connection, output_filepath, empty_table, export_cb, capture_callback_threads
+    ):
         """
         Due to a race condition, it's difficult to create a test with
         connection.abort_query() that ensures that an exception would be raised.
@@ -156,12 +307,16 @@ class TestExportToCallbackExceptions:
                 code="40007",
             )
 
-            with pytest.raises(ExaExportError) as ex:
-                connection.export_to_callback(
-                    callback=export_cb,
-                    dst=output_filepath,
-                    query_or_table=empty_table,
-                )
+            with capture_callback_threads(ExaSQLExportThread) as (
+                http_thread,
+                sql_thread,
+            ):
+                with pytest.raises(ExaExportError) as ex:
+                    connection.export_to_callback(
+                        callback=export_cb,
+                        dst=output_filepath,
+                        query_or_table=empty_table,
+                    )
 
         query_error_loc = 0
         if len(ex.value.exceptions) == 2:
@@ -170,22 +325,32 @@ class TestExportToCallbackExceptions:
         selected_exception = ex.value.exceptions[query_error_loc]
         assert isinstance(selected_exception, ExaQueryError)
         assert "Client requested execution abort." in selected_exception.message
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
 
     @staticmethod
-    def test_export_callback_and_sql_have_different_exceptions(connection):
+    def test_export_callback_and_sql_have_different_exceptions(
+        connection, capture_callback_threads
+    ):
         error = ValueError("Error from callback")
 
         def export_cb(pipe, dst, **kwargs):
             raise error
 
-        with pytest.raises(ExaExportError) as ex:
-            connection.export_to_callback(
-                callback=export_cb, dst=None, query_or_table="DOES_NOT_EXIST"
-            )
+        with capture_callback_threads(ExaSQLExportThread) as (
+            http_thread,
+            sql_thread,
+        ):
+            with pytest.raises(ExaExportError) as ex:
+                connection.export_to_callback(
+                    callback=export_cb, dst=None, query_or_table="DOES_NOT_EXIST"
+                )
 
         assert len(ex.value.exceptions) == 2
         assert ex.value.exceptions[0] == error
         assert isinstance(ex.value.exceptions[1], ExaQueryError)
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
 
 
 @pytest.mark.configuration

--- a/test/integration/import_and_export/export_to_callback_test.py
+++ b/test/integration/import_and_export/export_to_callback_test.py
@@ -166,10 +166,8 @@ class TestExportToCallbackExceptions:
         export_cb,
         capture_callback_threads,
     ):
-        error = BrokenPipeError("Broken pipe in http_thread")
-
         def write_final_chunk_with_exception(_handler):
-            raise error
+            raise BrokenPipeError("Broken pipe in http_thread")
 
         with patch.object(
             ExaHttpRequestHandler,

--- a/test/integration/import_and_export/export_to_callback_test.py
+++ b/test/integration/import_and_export/export_to_callback_test.py
@@ -229,10 +229,14 @@ class TestExportToCallbackExceptions:
     def test_sql_thread_has_outdated_database_license(
         connection,
         output_filepath,
-        empty_table,
-        export_cb,
+        fill_table,
         capture_callback_threads,
     ):
+        def streaming_export_cb(pipe, dst, **kwargs):
+            with dst.open("wb") as output_file:
+                while chunk := pipe.read(8192):
+                    output_file.write(chunk)
+
         license_error = ExaQueryError(
             connection=connection,
             query="EXPORT ...",
@@ -245,15 +249,16 @@ class TestExportToCallbackExceptions:
                 http_thread,
                 sql_thread,
             ):
-                with pytest.raises(ExaExportError, match="1 sub-exception") as ex:
+                with pytest.raises(ExaExportError, match="2 sub-exceptions") as ex:
                     connection.export_to_callback(
-                        callback=export_cb,
+                        callback=streaming_export_cb,
                         dst=output_filepath,
-                        query_or_table=empty_table,
+                        query_or_table=fill_table,
                     )
 
-        assert len(ex.value.exceptions) == 1
-        assert ex.value.exceptions[0] is license_error
+        assert len(ex.value.exceptions) == 2
+        assert isinstance(ex.value.exceptions[0], ValueError)
+        assert ex.value.exceptions[1] is license_error
         assert sql_thread.exc is license_error
         assert not http_thread.is_alive()
         assert not sql_thread.is_alive()

--- a/test/integration/import_and_export/import_from_callback_test.py
+++ b/test/integration/import_and_export/import_from_callback_test.py
@@ -10,6 +10,7 @@ from pyexasol.exceptions import (
     ExaQueryError,
     ExaRuntimeError,
 )
+from pyexasol.http_transport import ExaTCPServer
 
 
 @pytest.fixture
@@ -177,9 +178,17 @@ class TestImportFromCallbackExceptions:
     def test_http_thread_has_exception(
         connection, input_filepath, empty_table, import_cb
     ):
-        with patch("pyexasol.connection.ExaHttpThread.join_with_exc") as mock:
-            mock.side_effect = BrokenPipeError("Broken pipe in http_thread")
+        error = BrokenPipeError("Broken pipe in http_thread")
 
+        def handle_request_with_exception(_server):
+            raise error
+
+        with patch.object(
+            ExaTCPServer,
+            "handle_request",
+            autospec=True,
+            side_effect=handle_request_with_exception,
+        ):
             with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
                 connection.import_from_callback(
                     callback=import_cb,
@@ -194,6 +203,29 @@ class TestImportFromCallbackExceptions:
             "Following error occured while reading data"
             in ex.value.exceptions[1].message
         )
+
+    @staticmethod
+    def test_sql_thread_has_outdated_database_license(
+        connection, input_filepath, empty_table, import_cb
+    ):
+        license_error = ExaQueryError(
+            connection=connection,
+            query="IMPORT INTO ...",
+            code="42000",
+            message="Database license is out of date.",
+        )
+
+        with patch.object(connection, "execute", side_effect=license_error):
+            with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
+                connection.import_from_callback(
+                    callback=import_cb,
+                    src=input_filepath,
+                    table=empty_table,
+                )
+
+        assert len(ex.value.exceptions) == 2
+        assert isinstance(ex.value.exceptions[0], ValueError)
+        assert ex.value.exceptions[1] is license_error
 
     @staticmethod
     def test_sql_thread_has_exception(connection, input_filepath, import_cb):

--- a/test/integration/import_and_export/import_from_callback_test.py
+++ b/test/integration/import_and_export/import_from_callback_test.py
@@ -10,7 +10,12 @@ from pyexasol.exceptions import (
     ExaQueryError,
     ExaRuntimeError,
 )
-from pyexasol.http_transport import ExaTCPServer
+from pyexasol.http_transport import (
+    ExaHttpRequestHandler,
+    ExaHttpThread,
+    ExaSQLImportThread,
+    ExaTCPServer,
+)
 
 
 @pytest.fixture
@@ -175,10 +180,78 @@ class TestImportFromCallbackExceptions:
         assert type(ex.value.exceptions[1]) in (ExaCommunicationError, ExaRuntimeError)
 
     @staticmethod
-    def test_http_thread_has_exception(
+    def test_http_handler_failure_propagates_to_sql_thread(
+        connection, input_filepath, empty_table, import_cb, all_data
+    ):
+        error = BrokenPipeError("Broken pipe in http_thread")
+        input_filepath.write_text(all_data.csv_str())
+
+        http_thread = None
+        sql_thread = None
+
+        def create_http_thread(*args, **kwargs):
+            nonlocal http_thread
+            http_thread = ExaHttpThread(*args, **kwargs)
+            return http_thread
+
+        def create_sql_thread(*args, **kwargs):
+            nonlocal sql_thread
+            sql_thread = ExaSQLImportThread(*args, **kwargs)
+            return sql_thread
+
+        def write_chunk_with_exception(_handler, _data):
+            raise error
+
+        with patch.object(
+            ExaHttpRequestHandler,
+            "write_chunk",
+            autospec=True,
+            side_effect=write_chunk_with_exception,
+        ):
+            with (
+                patch(
+                    "pyexasol.connection.ExaHttpThread",
+                    side_effect=create_http_thread,
+                ),
+                patch(
+                    "pyexasol.connection.ExaSQLImportThread",
+                    side_effect=create_sql_thread,
+                ),
+            ):
+                with pytest.raises(ExaImportError, match="1 sub-exception") as ex:
+                    connection.import_from_callback(
+                        callback=import_cb,
+                        src=input_filepath,
+                        table=empty_table,
+                    )
+
+        assert len(ex.value.exceptions) == 1
+        assert isinstance(ex.value.exceptions[0], ExaQueryError)
+        assert isinstance(sql_thread.exc, ExaQueryError)
+        assert (
+            "Following error occured while reading data"
+            in ex.value.exceptions[0].message
+        )
+        assert not sql_thread.is_alive()
+        assert not http_thread.is_alive()
+
+    @staticmethod
+    def test_http_thread_captures_transport_exception(
         connection, input_filepath, empty_table, import_cb
     ):
         error = BrokenPipeError("Broken pipe in http_thread")
+        http_thread = None
+        sql_thread = None
+
+        def create_http_thread(*args, **kwargs):
+            nonlocal http_thread
+            http_thread = ExaHttpThread(*args, **kwargs)
+            return http_thread
+
+        def create_sql_thread(*args, **kwargs):
+            nonlocal sql_thread
+            sql_thread = ExaSQLImportThread(*args, **kwargs)
+            return sql_thread
 
         def handle_request_with_exception(_server):
             raise error
@@ -189,12 +262,22 @@ class TestImportFromCallbackExceptions:
             autospec=True,
             side_effect=handle_request_with_exception,
         ):
-            with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
-                connection.import_from_callback(
-                    callback=import_cb,
-                    src=input_filepath,
-                    table=empty_table,
-                )
+            with (
+                patch(
+                    "pyexasol.connection.ExaHttpThread",
+                    side_effect=create_http_thread,
+                ),
+                patch(
+                    "pyexasol.connection.ExaSQLImportThread",
+                    side_effect=create_sql_thread,
+                ),
+            ):
+                with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
+                    connection.import_from_callback(
+                        callback=import_cb,
+                        src=input_filepath,
+                        table=empty_table,
+                    )
 
         assert len(ex.value.exceptions) == 2
         assert isinstance(ex.value.exceptions[0], BrokenPipeError)
@@ -203,6 +286,9 @@ class TestImportFromCallbackExceptions:
             "Following error occured while reading data"
             in ex.value.exceptions[1].message
         )
+        assert http_thread.exc is error
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
 
     @staticmethod
     def test_sql_thread_has_outdated_database_license(
@@ -215,17 +301,43 @@ class TestImportFromCallbackExceptions:
             message="Database license is out of date.",
         )
 
+        http_thread = None
+        sql_thread = None
+
+        def create_http_thread(*args, **kwargs):
+            nonlocal http_thread
+            http_thread = ExaHttpThread(*args, **kwargs)
+            return http_thread
+
+        def create_sql_thread(*args, **kwargs):
+            nonlocal sql_thread
+            sql_thread = ExaSQLImportThread(*args, **kwargs)
+            return sql_thread
+
         with patch.object(connection, "execute", side_effect=license_error):
-            with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
-                connection.import_from_callback(
-                    callback=import_cb,
-                    src=input_filepath,
-                    table=empty_table,
-                )
+            with (
+                patch(
+                    "pyexasol.connection.ExaHttpThread",
+                    side_effect=create_http_thread,
+                ),
+                patch(
+                    "pyexasol.connection.ExaSQLImportThread",
+                    side_effect=create_sql_thread,
+                ),
+            ):
+                with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
+                    connection.import_from_callback(
+                        callback=import_cb,
+                        src=input_filepath,
+                        table=empty_table,
+                    )
 
         assert len(ex.value.exceptions) == 2
         assert isinstance(ex.value.exceptions[0], ValueError)
         assert ex.value.exceptions[1] is license_error
+        assert sql_thread.exc is license_error
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
 
     @staticmethod
     def test_sql_thread_has_exception(connection, input_filepath, import_cb):

--- a/test/integration/import_and_export/import_from_callback_test.py
+++ b/test/integration/import_and_export/import_from_callback_test.py
@@ -204,7 +204,11 @@ class TestImportFromCallbackExceptions:
 
         assert len(ex.value.exceptions) == 2
         # race condition: the caught exception depends on how far the thread was
-        assert type(ex.value.exceptions[1]) in (ExaCommunicationError, ExaRuntimeError)
+        assert type(ex.value.exceptions[1]) in (
+            ExaCommunicationError,
+            ExaRuntimeError,
+            OSError,
+        )
         assert sql_thread.exc is not None
         assert http_thread.exc is None
         assert not http_thread.is_alive()

--- a/test/integration/import_and_export/import_from_callback_test.py
+++ b/test/integration/import_and_export/import_from_callback_test.py
@@ -1,5 +1,4 @@
 import time
-from contextlib import contextmanager
 from test.integration.import_and_export.helper import select_result
 from unittest.mock import patch
 
@@ -13,7 +12,6 @@ from pyexasol.exceptions import (
 )
 from pyexasol.http_transport import (
     ExaHttpRequestHandler,
-    ExaHttpThread,
     ExaSQLImportThread,
     ExaTCPServer,
 )
@@ -34,42 +32,6 @@ def import_cb():
         pipe.write(src.read_bytes())
 
     return _callback
-
-
-@contextmanager
-def capture_import_threads():
-    """Capture the real worker threads created by import_from_callback()."""
-    http_thread = ThreadHelper()
-    sql_thread = ThreadHelper()
-
-    def create_http_thread(*args, **kwargs):
-        http_thread.instance = ExaHttpThread(*args, **kwargs)
-        return http_thread.instance
-
-    def create_sql_thread(*args, **kwargs):
-        sql_thread.instance = ExaSQLImportThread(*args, **kwargs)
-        return sql_thread.instance
-
-    with (
-        patch("pyexasol.connection.ExaHttpThread", side_effect=create_http_thread),
-        patch(
-            "pyexasol.connection.ExaSQLImportThread",
-            side_effect=create_sql_thread,
-        ),
-    ):
-        yield http_thread, sql_thread
-
-
-class ThreadHelper:
-    """Proxy exposing a worker thread created inside the context manager."""
-
-    def __init__(self):
-        self.instance = None
-
-    def __getattr__(self, attribute):
-        if self.instance is None:
-            raise AssertionError("Thread was not created")
-        return getattr(self.instance, attribute)
 
 
 @pytest.mark.etl
@@ -179,13 +141,18 @@ class TestImportGeneral:
 @pytest.mark.exceptions
 class TestImportFromCallbackExceptions:
     @staticmethod
-    def test_import_callback_has_exception(connection, empty_table):
+    def test_import_callback_has_exception(
+        connection, empty_table, capture_callback_threads
+    ):
         error = ValueError("Error from callback")
 
         def import_cb(pipe, src, **kwargs):
             raise error
 
-        with capture_import_threads() as (http_thread, sql_thread):
+        with capture_callback_threads(ExaSQLImportThread) as (
+            http_thread,
+            sql_thread,
+        ):
             with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
                 connection.import_from_callback(
                     callback=import_cb, src=None, table=empty_table
@@ -203,7 +170,7 @@ class TestImportFromCallbackExceptions:
 
     @staticmethod
     def test_closed_ws_connection(
-        connection_factory, connection, empty_table, import_cb
+        connection_factory, connection, empty_table, import_cb, capture_callback_threads
     ):
         new_connection = connection_factory()
 
@@ -212,7 +179,10 @@ class TestImportFromCallbackExceptions:
             time.sleep(2)
             import_cb(pipe, src, **kwargs)
 
-        with capture_import_threads() as (http_thread, sql_thread):
+        with capture_callback_threads(ExaSQLImportThread) as (
+            http_thread,
+            sql_thread,
+        ):
             with pytest.raises(ExaImportError) as ex:
                 new_connection.import_from_callback(
                     import_cb_with_close, None, empty_table
@@ -226,7 +196,12 @@ class TestImportFromCallbackExceptions:
 
     @staticmethod
     def test_http_handler_failure_propagates_to_sql_thread(
-        connection, input_filepath, empty_table, import_cb, all_data
+        connection,
+        input_filepath,
+        empty_table,
+        import_cb,
+        all_data,
+        capture_callback_threads,
     ):
         error = BrokenPipeError("Broken pipe in http_thread")
         input_filepath.write_text(all_data.csv_str())
@@ -240,7 +215,10 @@ class TestImportFromCallbackExceptions:
             autospec=True,
             side_effect=write_chunk_with_exception,
         ):
-            with capture_import_threads() as (http_thread, sql_thread):
+            with capture_callback_threads(ExaSQLImportThread) as (
+                http_thread,
+                sql_thread,
+            ):
                 with pytest.raises(ExaImportError, match="1 sub-exception") as ex:
                     connection.import_from_callback(
                         callback=import_cb,
@@ -260,7 +238,7 @@ class TestImportFromCallbackExceptions:
 
     @staticmethod
     def test_http_thread_captures_transport_exception(
-        connection, input_filepath, empty_table, import_cb
+        connection, input_filepath, empty_table, import_cb, capture_callback_threads
     ):
         error = BrokenPipeError("Broken pipe in http_thread")
 
@@ -273,7 +251,10 @@ class TestImportFromCallbackExceptions:
             autospec=True,
             side_effect=handle_request_with_exception,
         ):
-            with capture_import_threads() as (http_thread, sql_thread):
+            with capture_callback_threads(ExaSQLImportThread) as (
+                http_thread,
+                sql_thread,
+            ):
                 with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
                     connection.import_from_callback(
                         callback=import_cb,
@@ -294,7 +275,11 @@ class TestImportFromCallbackExceptions:
 
     @staticmethod
     def test_sql_thread_has_outdated_database_license(
-        connection, input_filepath, empty_table, import_cb
+        connection,
+        input_filepath,
+        empty_table,
+        import_cb,
+        capture_callback_threads,
     ):
         license_error = ExaQueryError(
             connection=connection,
@@ -304,7 +289,10 @@ class TestImportFromCallbackExceptions:
         )
 
         with patch.object(connection, "execute", side_effect=license_error):
-            with capture_import_threads() as (http_thread, sql_thread):
+            with capture_callback_threads(ExaSQLImportThread) as (
+                http_thread,
+                sql_thread,
+            ):
                 with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
                     connection.import_from_callback(
                         callback=import_cb,
@@ -321,8 +309,13 @@ class TestImportFromCallbackExceptions:
         assert http_thread.server.socket.fileno() == -1
 
     @staticmethod
-    def test_sql_thread_has_exception(connection, input_filepath, import_cb):
-        with capture_import_threads() as (http_thread, sql_thread):
+    def test_sql_thread_has_exception(
+        connection, input_filepath, import_cb, capture_callback_threads
+    ):
+        with capture_callback_threads(ExaSQLImportThread) as (
+            http_thread,
+            sql_thread,
+        ):
             with pytest.raises(ExaImportError, match="1 sub-exception") as ex:
                 connection.import_from_callback(
                     callback=import_cb, src=input_filepath, table="DOES_NOT_EXIST"
@@ -335,7 +328,9 @@ class TestImportFromCallbackExceptions:
         assert not sql_thread.is_alive()
 
     @staticmethod
-    def test_abort_query(connection, input_filepath, empty_table, import_cb):
+    def test_abort_query(
+        connection, input_filepath, empty_table, import_cb, capture_callback_threads
+    ):
         """
         Due to a race condition, it's difficult to create a test with
         connection.abort_query() that ensures that an exception would be raised.
@@ -349,8 +344,10 @@ class TestImportFromCallbackExceptions:
                 connection=connection,
                 code="40007",
             )
-
-            with capture_import_threads() as (http_thread, sql_thread):
+            with capture_callback_threads(ExaSQLImportThread) as (
+                http_thread,
+                sql_thread,
+            ):
                 with pytest.raises(ExaImportError) as ex:
                     connection.import_from_callback(
                         callback=import_cb,

--- a/test/integration/import_and_export/import_from_callback_test.py
+++ b/test/integration/import_and_export/import_from_callback_test.py
@@ -170,7 +170,7 @@ class TestImportFromCallbackExceptions:
 
     @staticmethod
     def test_closed_ws_connection(
-        connection_factory, connection, empty_table, import_cb, capture_callback_threads
+        connection_factory, empty_table, import_cb, capture_callback_threads
     ):
         new_connection = connection_factory()
 

--- a/test/integration/import_and_export/import_from_callback_test.py
+++ b/test/integration/import_and_export/import_from_callback_test.py
@@ -269,11 +269,12 @@ class TestImportFromCallbackExceptions:
         connection, input_filepath, empty_table, import_cb, capture_callback_threads
     ):
         """
-        ``ExaTCPServer.handle_request`` raises an exception in the HTTP
-        thread:
-          - Because the HTTP server can no longer carry the data, the
-            concurrently running SQL thread's IMPORT receives a transport
-            failure and raises an ``ExaQueryError``.
+        The HTTP thread runs an ``ExaTCPServer``. Its
+        ``ExaTCPServer.handle_request`` method raises a transport exception:
+          - The HTTP thread captures the exception raised by the TCP server.
+          - Because the TCP server can no longer carry the data, the concurrently
+            running SQL thread's IMPORT receives a transport failure and raises an
+            ``ExaQueryError``.
           - The callback only supplies data and completes normally.
         """
         error = BrokenPipeError("Broken pipe in http_thread")

--- a/test/integration/import_and_export/import_from_callback_test.py
+++ b/test/integration/import_and_export/import_from_callback_test.py
@@ -332,10 +332,11 @@ class TestImportFromCallbackExceptions:
         connection, input_filepath, empty_table, import_cb, capture_callback_threads
     ):
         """
-        Due to a race condition, it's difficult to create a test with
-        connection.abort_query() that ensures that an exception would be raised.
-        Thus, we mock that here. Still, there is a race condition whether 1 or 2
-        exceptions are raised.
+        Mock the SQL thread to deterministically record an abort
+        ``ExaQueryError``. Terminating the HTTP thread closes the callback
+        pipe while the callback is still active, so the HTTP/callback path
+        contributes a second exception. This test therefore expects two
+        exceptions.
         """
         with patch("pyexasol.connection.ExaSQLImportThread.run_sql") as mock:
             mock.side_effect = ExaQueryError(
@@ -355,11 +356,9 @@ class TestImportFromCallbackExceptions:
                         table=empty_table,
                     )
 
-        query_error_loc = 0
-        if len(ex.value.exceptions) == 2:
-            query_error_loc = 1
+        assert len(ex.value.exceptions) == 2
 
-        selected_exception = ex.value.exceptions[query_error_loc]
+        selected_exception = ex.value.exceptions[1]
         assert isinstance(selected_exception, ExaQueryError)
         assert "Client requested execution abort." in selected_exception.message
         assert not http_thread.is_alive()

--- a/test/integration/import_and_export/import_from_callback_test.py
+++ b/test/integration/import_and_export/import_from_callback_test.py
@@ -1,4 +1,3 @@
-import time
 from test.integration.import_and_export.helper import select_result
 from unittest.mock import patch
 
@@ -144,6 +143,14 @@ class TestImportFromCallbackExceptions:
     def test_import_callback_has_exception(
         connection, empty_table, capture_callback_threads
     ):
+        """
+        The defined callback function raises an exception:
+          - That failure closes the write pipe before the IMPORT request can finish.
+          - The SQL thread therefore receives an incomplete request from Exasol and
+            raises an ``ExaQueryError``.
+          - The HTTP thread is only stopped by cleanup; it does not perform the failed
+          SQL operation, and it,therefore, is not expected to have its own exception.
+        """
         error = ValueError("Error from callback")
 
         def import_cb(pipe, src, **kwargs):
@@ -172,11 +179,18 @@ class TestImportFromCallbackExceptions:
     def test_closed_ws_connection(
         connection_factory, empty_table, import_cb, capture_callback_threads
     ):
+        """
+        The callback closes the WebSocket while both workers are using it:
+          - Thus, the calling thread fails while using the callback pipe.
+          - The SQL thread fails because its database request loses the WebSocket
+            transport.
+        - The HTTP thread is terminated by the SQL thread, but it does not raise an
+          exception.
+        """
         new_connection = connection_factory()
 
         def import_cb_with_close(pipe, src, **kwargs):
             new_connection.close(disconnect=False)
-            time.sleep(2)
             import_cb(pipe, src, **kwargs)
 
         with capture_callback_threads(ExaSQLImportThread) as (
@@ -191,6 +205,8 @@ class TestImportFromCallbackExceptions:
         assert len(ex.value.exceptions) == 2
         # race condition: the caught exception depends on how far the thread was
         assert type(ex.value.exceptions[1]) in (ExaCommunicationError, ExaRuntimeError)
+        assert sql_thread.exc is not None
+        assert http_thread.exc is None
         assert not http_thread.is_alive()
         assert not sql_thread.is_alive()
 
@@ -203,6 +219,14 @@ class TestImportFromCallbackExceptions:
         all_data,
         capture_callback_threads,
     ):
+        """
+        The HTTP thread raises an exception while writing a chunk:
+         - The handler catches that failure and closes its transport.
+         - The SQL thread is executing the IMPORT that depends on that transport, so it
+           receives the truncated request and records an ``ExaQueryError``.
+        - The callback is not the failing component, and the HTTP exception is not
+        propagated separately. Hence, they do not raise exceptions.
+        """
         error = BrokenPipeError("Broken pipe in http_thread")
         input_filepath.write_text(all_data.csv_str())
 
@@ -240,6 +264,14 @@ class TestImportFromCallbackExceptions:
     def test_http_thread_captures_transport_exception(
         connection, input_filepath, empty_table, import_cb, capture_callback_threads
     ):
+        """
+        ``ExaTCPServer.handle_request`` raises an exception in the HTTP
+        thread:
+          - Because the HTTP server can no longer carry the data, the
+            concurrently running SQL thread's IMPORT receives a transport
+            failure and raises an ``ExaQueryError``.
+          - The callback only supplies data and completes normally.
+        """
         error = BrokenPipeError("Broken pipe in http_thread")
 
         def handle_request_with_exception(_server):
@@ -281,6 +313,13 @@ class TestImportFromCallbackExceptions:
         import_cb,
         capture_callback_threads,
     ):
+        """
+        The SQL thread raises an exception before it can consume the import data:
+          - The SQL thread terminates the HTTP thread and closes the pipe.
+          - The callback then attempts to use that pipe and raises a ``ValueError``.
+          - The HTTP thread is only being terminated by the SQL thread, so it is not
+            expected to report a separate exception.
+        """
         license_error = ExaQueryError(
             connection=connection,
             query="IMPORT INTO ...",
@@ -304,6 +343,7 @@ class TestImportFromCallbackExceptions:
         assert isinstance(ex.value.exceptions[0], ValueError)
         assert ex.value.exceptions[1] is license_error
         assert sql_thread.exc is license_error
+        assert http_thread.exc is None
         assert not http_thread.is_alive()
         assert not sql_thread.is_alive()
         assert http_thread.server.socket.fileno() == -1
@@ -312,6 +352,17 @@ class TestImportFromCallbackExceptions:
     def test_sql_thread_has_exception(
         connection, input_filepath, import_cb, capture_callback_threads
     ):
+        """
+        The SQL thread is the component executing the IMPORT query, so it detects
+        the missing table and records an ``ExaQueryError``:
+          - The SQL thread terminates the HTTP thread, which exits without an
+            independent exception.
+          - The callback supplies the input data but does not raise an exception.
+          - Cleanup joins the HTTP thread first, then joins the SQL thread and
+            propagates its ``ExaQueryError``.
+        The aggregated ``ExaImportError`` therefore contains only the SQL-thread
+        exception.
+        """
         with capture_callback_threads(ExaSQLImportThread) as (
             http_thread,
             sql_thread,
@@ -323,6 +374,8 @@ class TestImportFromCallbackExceptions:
 
         assert len(ex.value.exceptions) == 1
         assert isinstance(ex.value.exceptions[0], ExaQueryError)
+        assert isinstance(sql_thread.exc, ExaQueryError)
+        assert http_thread.exc is None
         assert "object DOES_NOT_EXIST not found" in ex.value.exceptions[0].message
         assert not http_thread.is_alive()
         assert not sql_thread.is_alive()
@@ -365,20 +418,39 @@ class TestImportFromCallbackExceptions:
         assert not sql_thread.is_alive()
 
     @staticmethod
-    def test_export_callback_and_sql_have_different_exceptions(connection):
+    def test_import_callback_and_sql_have_different_exceptions(
+        connection, capture_callback_threads
+    ):
+        """
+        The callback raises a ``ValueError`` before it can provide input:
+          - The SQL thread independently reports the missing-table
+            ``ExaQueryError`` because it is the only component executing the
+            query.
+          - The HTTP thread is terminated during cleanup and does not have an
+            independent failure.
+        """
         error = ValueError("Error from callback")
 
         def import_cb(pipe, src, **kwargs):
             raise error
 
-        with pytest.raises(ExaImportError) as ex:
-            connection.import_from_callback(
-                callback=import_cb, src=None, table="DOES_NOT_EXIST"
-            )
+        with capture_callback_threads(ExaSQLImportThread) as (
+            http_thread,
+            sql_thread,
+        ):
+            with pytest.raises(ExaImportError) as ex:
+                connection.import_from_callback(
+                    callback=import_cb, src=None, table="DOES_NOT_EXIST"
+                )
 
         assert ex.value.exceptions[0] == error
         assert isinstance(ex.value.exceptions[1], ExaQueryError)
         assert len(ex.value.exceptions) == 2
+        assert sql_thread.exc is ex.value.exceptions[1]
+        assert http_thread.exc is None
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
+        assert http_thread.server.socket.fileno() == -1
 
 
 @pytest.mark.configuration

--- a/test/integration/import_and_export/import_from_callback_test.py
+++ b/test/integration/import_and_export/import_from_callback_test.py
@@ -149,7 +149,7 @@ class TestImportFromCallbackExceptions:
           - The SQL thread therefore receives an incomplete request from Exasol and
             raises an ``ExaQueryError``.
           - The HTTP thread is only stopped by cleanup; it does not perform the failed
-          SQL operation, and it,therefore, is not expected to have its own exception.
+          SQL operation, and therefore, it is not expected to have its own exception.
         """
         error = ValueError("Error from callback")
 
@@ -271,7 +271,7 @@ class TestImportFromCallbackExceptions:
         connection, input_filepath, empty_table, import_cb, capture_callback_threads
     ):
         """
-        The TCP server (``ExaTCPServer'', owned by the HTTP thread) raises a transport
+        The TCP server (``ExaTCPServer``, owned by the HTTP thread) raises a transport
         exception:
           - The HTTP thread captures the exception raised by its TCP server.
           - Because the TCP server can no longer carry the data, the concurrently

--- a/test/integration/import_and_export/import_from_callback_test.py
+++ b/test/integration/import_and_export/import_from_callback_test.py
@@ -180,12 +180,13 @@ class TestImportFromCallbackExceptions:
         connection_factory, empty_table, import_cb, capture_callback_threads
     ):
         """
-        The callback closes the WebSocket while both workers are using it:
+        The callback closes the WebSocket while the SQL thread and the HTTP thread
+        are using it:
           - Thus, the calling thread fails while using the callback pipe.
           - The SQL thread fails because its database request loses the WebSocket
             transport.
-        - The HTTP thread is terminated by the SQL thread, but it does not raise an
-          exception.
+          - The SQL thread terminates the HTTP thread and its TCP server, but the
+            HTTP thread does not raise an exception of its own.
         """
         new_connection = connection_factory()
 
@@ -224,12 +225,13 @@ class TestImportFromCallbackExceptions:
         capture_callback_threads,
     ):
         """
-        The HTTP thread raises an exception while writing a chunk:
-         - The handler catches that failure and closes its transport.
-         - The SQL thread is executing the IMPORT that depends on that transport, so it
-           receives the truncated request and records an ``ExaQueryError``.
-        - The callback is not the failing component, and the HTTP exception is not
-        propagated separately. Hence, they do not raise exceptions.
+        The TCP server (``ExaTCPServer``) owned by the HTTP thread raises an exception
+        while writing a chunk of data:
+          - The HTTP thread captures the handler exception and closes its transport.
+          - The SQL thread is executing the IMPORT that depends on that transport,
+            so it receives the truncated request and records an ``ExaQueryError``.
+          - The callback is not the failing component and does not raise an
+            exception.
         """
         error = BrokenPipeError("Broken pipe in http_thread")
         input_filepath.write_text(all_data.csv_str())
@@ -269,9 +271,9 @@ class TestImportFromCallbackExceptions:
         connection, input_filepath, empty_table, import_cb, capture_callback_threads
     ):
         """
-        The HTTP thread runs an ``ExaTCPServer``. Its
-        ``ExaTCPServer.handle_request`` method raises a transport exception:
-          - The HTTP thread captures the exception raised by the TCP server.
+        The TCP server (``ExaTCPServer'', owned by the HTTP thread) raises a transport
+        exception:
+          - The HTTP thread captures the exception raised by its TCP server.
           - Because the TCP server can no longer carry the data, the concurrently
             running SQL thread's IMPORT receives a transport failure and raises an
             ``ExaQueryError``.
@@ -322,8 +324,8 @@ class TestImportFromCallbackExceptions:
         The SQL thread raises an exception before it can consume the import data:
           - The SQL thread terminates the HTTP thread and closes the pipe.
           - The callback then attempts to use that pipe and raises a ``ValueError``.
-          - The HTTP thread is only being terminated by the SQL thread, so it is not
-            expected to report a separate exception.
+          - The HTTP thread is only being terminated by the SQL thread, so it does not
+            report a separate exception.
         """
         license_error = ExaQueryError(
             connection=connection,
@@ -358,10 +360,9 @@ class TestImportFromCallbackExceptions:
         connection, input_filepath, import_cb, capture_callback_threads
     ):
         """
-        The SQL thread is the component executing the IMPORT query, so it detects
-        the missing table and records an ``ExaQueryError``:
-          - The SQL thread terminates the HTTP thread, which exits without an
-            independent exception.
+        The SQL thread executes the IMPORT query, so it detects the missing table
+        and records an ``ExaQueryError``:
+          - The SQL thread terminates the HTTP thread, which exits without an exception.
           - The callback supplies the input data but does not raise an exception.
           - Cleanup joins the HTTP thread first, then joins the SQL thread and
             propagates its ``ExaQueryError``.
@@ -390,11 +391,10 @@ class TestImportFromCallbackExceptions:
         connection, input_filepath, empty_table, import_cb, capture_callback_threads
     ):
         """
-        Mock the SQL thread to deterministically record an abort
-        ``ExaQueryError``. Terminating the HTTP thread closes the callback
-        pipe while the callback is still active, so the HTTP/callback path
-        contributes a second exception. This test therefore expects two
-        exceptions.
+        The SQL thread raises an ``ExaQueryError`` because the query is aborted:
+          - The SQL thread terminates the HTTP thread.
+          - The callback pipe is closed while the callback is still active, so the
+            HTTP/callback path contributes a second exception.
         """
         with patch("pyexasol.connection.ExaSQLImportThread.run_sql") as mock:
             mock.side_effect = ExaQueryError(
@@ -427,12 +427,12 @@ class TestImportFromCallbackExceptions:
         connection, capture_callback_threads
     ):
         """
-        The callback raises a ``ValueError`` before it can provide input:
+        The callback in the calling thread raises a ``ValueError`` before it can
+        provide input. The SQL thread independently executes the IMPORT:
           - The SQL thread independently reports the missing-table
             ``ExaQueryError`` because it is the only component executing the
             query.
-          - The HTTP thread is terminated during cleanup and does not have an
-            independent failure.
+          - The HTTP thread is terminated during cleanup and does not raise an exception.
         """
         error = ValueError("Error from callback")
 

--- a/test/integration/import_and_export/import_from_callback_test.py
+++ b/test/integration/import_and_export/import_from_callback_test.py
@@ -1,4 +1,5 @@
 import time
+from contextlib import contextmanager
 from test.integration.import_and_export.helper import select_result
 from unittest.mock import patch
 
@@ -33,6 +34,42 @@ def import_cb():
         pipe.write(src.read_bytes())
 
     return _callback
+
+
+@contextmanager
+def capture_import_threads():
+    """Capture the real worker threads created by import_from_callback()."""
+    http_thread = ThreadHelper()
+    sql_thread = ThreadHelper()
+
+    def create_http_thread(*args, **kwargs):
+        http_thread.instance = ExaHttpThread(*args, **kwargs)
+        return http_thread.instance
+
+    def create_sql_thread(*args, **kwargs):
+        sql_thread.instance = ExaSQLImportThread(*args, **kwargs)
+        return sql_thread.instance
+
+    with (
+        patch("pyexasol.connection.ExaHttpThread", side_effect=create_http_thread),
+        patch(
+            "pyexasol.connection.ExaSQLImportThread",
+            side_effect=create_sql_thread,
+        ),
+    ):
+        yield http_thread, sql_thread
+
+
+class ThreadHelper:
+    """Proxy exposing a worker thread created inside the context manager."""
+
+    def __init__(self):
+        self.instance = None
+
+    def __getattr__(self, attribute):
+        if self.instance is None:
+            raise AssertionError("Thread was not created")
+        return getattr(self.instance, attribute)
 
 
 @pytest.mark.etl
@@ -148,10 +185,11 @@ class TestImportFromCallbackExceptions:
         def import_cb(pipe, src, **kwargs):
             raise error
 
-        with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
-            connection.import_from_callback(
-                callback=import_cb, src=None, table=empty_table
-            )
+        with capture_import_threads() as (http_thread, sql_thread):
+            with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
+                connection.import_from_callback(
+                    callback=import_cb, src=None, table=empty_table
+                )
 
         assert len(ex.value.exceptions) == 2
         assert ex.value.exceptions[0] == error
@@ -160,6 +198,8 @@ class TestImportFromCallbackExceptions:
             "Following error occured while reading data"
             in ex.value.exceptions[1].message
         )
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
 
     @staticmethod
     def test_closed_ws_connection(
@@ -172,12 +212,17 @@ class TestImportFromCallbackExceptions:
             time.sleep(2)
             import_cb(pipe, src, **kwargs)
 
-        with pytest.raises(ExaImportError) as ex:
-            new_connection.import_from_callback(import_cb_with_close, None, empty_table)
+        with capture_import_threads() as (http_thread, sql_thread):
+            with pytest.raises(ExaImportError) as ex:
+                new_connection.import_from_callback(
+                    import_cb_with_close, None, empty_table
+                )
 
         assert len(ex.value.exceptions) == 2
         # race condition: the caught exception depends on how far the thread was
         assert type(ex.value.exceptions[1]) in (ExaCommunicationError, ExaRuntimeError)
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
 
     @staticmethod
     def test_http_handler_failure_propagates_to_sql_thread(
@@ -185,19 +230,6 @@ class TestImportFromCallbackExceptions:
     ):
         error = BrokenPipeError("Broken pipe in http_thread")
         input_filepath.write_text(all_data.csv_str())
-
-        http_thread = None
-        sql_thread = None
-
-        def create_http_thread(*args, **kwargs):
-            nonlocal http_thread
-            http_thread = ExaHttpThread(*args, **kwargs)
-            return http_thread
-
-        def create_sql_thread(*args, **kwargs):
-            nonlocal sql_thread
-            sql_thread = ExaSQLImportThread(*args, **kwargs)
-            return sql_thread
 
         def write_chunk_with_exception(_handler, _data):
             raise error
@@ -208,16 +240,7 @@ class TestImportFromCallbackExceptions:
             autospec=True,
             side_effect=write_chunk_with_exception,
         ):
-            with (
-                patch(
-                    "pyexasol.connection.ExaHttpThread",
-                    side_effect=create_http_thread,
-                ),
-                patch(
-                    "pyexasol.connection.ExaSQLImportThread",
-                    side_effect=create_sql_thread,
-                ),
-            ):
+            with capture_import_threads() as (http_thread, sql_thread):
                 with pytest.raises(ExaImportError, match="1 sub-exception") as ex:
                     connection.import_from_callback(
                         callback=import_cb,
@@ -240,18 +263,6 @@ class TestImportFromCallbackExceptions:
         connection, input_filepath, empty_table, import_cb
     ):
         error = BrokenPipeError("Broken pipe in http_thread")
-        http_thread = None
-        sql_thread = None
-
-        def create_http_thread(*args, **kwargs):
-            nonlocal http_thread
-            http_thread = ExaHttpThread(*args, **kwargs)
-            return http_thread
-
-        def create_sql_thread(*args, **kwargs):
-            nonlocal sql_thread
-            sql_thread = ExaSQLImportThread(*args, **kwargs)
-            return sql_thread
 
         def handle_request_with_exception(_server):
             raise error
@@ -262,16 +273,7 @@ class TestImportFromCallbackExceptions:
             autospec=True,
             side_effect=handle_request_with_exception,
         ):
-            with (
-                patch(
-                    "pyexasol.connection.ExaHttpThread",
-                    side_effect=create_http_thread,
-                ),
-                patch(
-                    "pyexasol.connection.ExaSQLImportThread",
-                    side_effect=create_sql_thread,
-                ),
-            ):
+            with capture_import_threads() as (http_thread, sql_thread):
                 with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
                     connection.import_from_callback(
                         callback=import_cb,
@@ -301,30 +303,8 @@ class TestImportFromCallbackExceptions:
             message="Database license is out of date.",
         )
 
-        http_thread = None
-        sql_thread = None
-
-        def create_http_thread(*args, **kwargs):
-            nonlocal http_thread
-            http_thread = ExaHttpThread(*args, **kwargs)
-            return http_thread
-
-        def create_sql_thread(*args, **kwargs):
-            nonlocal sql_thread
-            sql_thread = ExaSQLImportThread(*args, **kwargs)
-            return sql_thread
-
         with patch.object(connection, "execute", side_effect=license_error):
-            with (
-                patch(
-                    "pyexasol.connection.ExaHttpThread",
-                    side_effect=create_http_thread,
-                ),
-                patch(
-                    "pyexasol.connection.ExaSQLImportThread",
-                    side_effect=create_sql_thread,
-                ),
-            ):
+            with capture_import_threads() as (http_thread, sql_thread):
                 with pytest.raises(ExaImportError, match="2 sub-exceptions") as ex:
                     connection.import_from_callback(
                         callback=import_cb,
@@ -338,17 +318,21 @@ class TestImportFromCallbackExceptions:
         assert sql_thread.exc is license_error
         assert not http_thread.is_alive()
         assert not sql_thread.is_alive()
+        assert http_thread.server.socket.fileno() == -1
 
     @staticmethod
     def test_sql_thread_has_exception(connection, input_filepath, import_cb):
-        with pytest.raises(ExaImportError, match="1 sub-exception") as ex:
-            connection.import_from_callback(
-                callback=import_cb, src=input_filepath, table="DOES_NOT_EXIST"
-            )
+        with capture_import_threads() as (http_thread, sql_thread):
+            with pytest.raises(ExaImportError, match="1 sub-exception") as ex:
+                connection.import_from_callback(
+                    callback=import_cb, src=input_filepath, table="DOES_NOT_EXIST"
+                )
 
         assert len(ex.value.exceptions) == 1
         assert isinstance(ex.value.exceptions[0], ExaQueryError)
         assert "object DOES_NOT_EXIST not found" in ex.value.exceptions[0].message
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
 
     @staticmethod
     def test_abort_query(connection, input_filepath, empty_table, import_cb):
@@ -366,12 +350,13 @@ class TestImportFromCallbackExceptions:
                 code="40007",
             )
 
-            with pytest.raises(ExaImportError) as ex:
-                connection.import_from_callback(
-                    callback=import_cb,
-                    src=input_filepath,
-                    table=empty_table,
-                )
+            with capture_import_threads() as (http_thread, sql_thread):
+                with pytest.raises(ExaImportError) as ex:
+                    connection.import_from_callback(
+                        callback=import_cb,
+                        src=input_filepath,
+                        table=empty_table,
+                    )
 
         query_error_loc = 0
         if len(ex.value.exceptions) == 2:
@@ -380,6 +365,8 @@ class TestImportFromCallbackExceptions:
         selected_exception = ex.value.exceptions[query_error_loc]
         assert isinstance(selected_exception, ExaQueryError)
         assert "Client requested execution abort." in selected_exception.message
+        assert not http_thread.is_alive()
+        assert not sql_thread.is_alive()
 
     @staticmethod
     def test_export_callback_and_sql_have_different_exceptions(connection):

--- a/test/unit/connection/import_and_export_callback_test.py
+++ b/test/unit/connection/import_and_export_callback_test.py
@@ -17,10 +17,10 @@ def mock_http_thread():
         instance.write_pipe.__enter__.return_value = MagicMock(spec=["write"])
 
         def construct_http_thread(*args, **kwargs):
-            thread_event = kwargs.get("thread_event")
-            if thread_event is not None:
+            worker_finished_event = kwargs.get("worker_finished_event")
+            if worker_finished_event is not None:
                 # The real HTTP thread signals this event when it finishes.
-                thread_event.set()
+                worker_finished_event.set()
             return instance
 
         mock_cls.side_effect = construct_http_thread
@@ -117,7 +117,7 @@ class TestExportToCallback:
         assert sql_kwargs["query_or_table"] == "dummy_table"
         # verify export_params=None maps to empty dictionary
         assert sql_kwargs["export_params"] == {}
-        assert sql_kwargs["thread_event"].is_set()
+        assert sql_kwargs["worker_finished_event"].is_set()
 
         # verify callback_params=None maps to empty dictionary
         _, callback_kwargs = callback_spy.call_args
@@ -159,12 +159,12 @@ class TestImportFromCallback:
         # this is set to self.options["compression"]
         _, http_kwargs = mock_http_thread.call_args
         assert http_kwargs["compression"] is exa_conn.options["compression"]
-        assert http_kwargs["thread_event"].is_set()
+        assert http_kwargs["worker_finished_event"].is_set()
 
         # verify import_params=None maps to empty dictionary
         _, sql_kwargs = mock_sql_import_thread.call_args
         assert sql_kwargs["import_params"] == {}
-        assert sql_kwargs["thread_event"].is_set()
+        assert sql_kwargs["worker_finished_event"].is_set()
 
         # verify callback_params=None maps to empty dictionary
         _, callback_kwargs = callback_spy.call_args

--- a/test/unit/connection/import_and_export_callback_test.py
+++ b/test/unit/connection/import_and_export_callback_test.py
@@ -15,6 +15,15 @@ def mock_http_thread():
         instance = mock_cls.return_value
         instance.write_pipe = MagicMock()
         instance.write_pipe.__enter__.return_value = MagicMock(spec=["write"])
+
+        def construct_http_thread(*args, **kwargs):
+            thread_event = kwargs.get("thread_event")
+            if thread_event is not None:
+                # The real HTTP thread signals this event when it finishes.
+                thread_event.set()
+            return instance
+
+        mock_cls.side_effect = construct_http_thread
         yield mock_cls
 
 
@@ -147,8 +156,9 @@ class TestImportFromCallback:
 
         # verify compression set as expected when import_params=None, then
         # this is set to self.options["compression"]
-        http_args, _ = mock_http_thread.call_args
+        http_args, http_kwargs = mock_http_thread.call_args
         assert http_args[2] is exa_conn.options["compression"]
+        assert http_kwargs["thread_event"].is_set()
 
         # verify import_params=None maps to empty dictionary
         sql_args, _ = mock_sql_import_thread.call_args

--- a/test/unit/connection/import_and_export_callback_test.py
+++ b/test/unit/connection/import_and_export_callback_test.py
@@ -107,16 +107,17 @@ class TestExportToCallback:
         mock_sql_export_thread.return_value.start.assert_called_once()
         assert result == "success_marker"
 
-        # verify compression set as expected when import_params=None, then
+        # verify compression set as expected when export_params=None, then
         # this is set to self.options["compression"]
-        http_args, _ = mock_http_thread.call_args
-        assert http_args[2] is exa_conn.options["compression"]
+        _, http_kwargs = mock_http_thread.call_args
+        assert http_kwargs["compression"] is exa_conn.options["compression"]
 
-        sql_args, _ = mock_sql_export_thread.call_args
+        _, sql_kwargs = mock_sql_export_thread.call_args
         # verify query_params=None would format query_or_table
-        assert sql_args[2] == "dummy_table"
-        # verify import_params=None maps to empty dictionary
-        assert sql_args[3] == {}
+        assert sql_kwargs["query_or_table"] == "dummy_table"
+        # verify export_params=None maps to empty dictionary
+        assert sql_kwargs["export_params"] == {}
+        assert sql_kwargs["thread_event"].is_set()
 
         # verify callback_params=None maps to empty dictionary
         _, callback_kwargs = callback_spy.call_args
@@ -156,13 +157,14 @@ class TestImportFromCallback:
 
         # verify compression set as expected when import_params=None, then
         # this is set to self.options["compression"]
-        http_args, http_kwargs = mock_http_thread.call_args
-        assert http_args[2] is exa_conn.options["compression"]
+        _, http_kwargs = mock_http_thread.call_args
+        assert http_kwargs["compression"] is exa_conn.options["compression"]
         assert http_kwargs["thread_event"].is_set()
 
         # verify import_params=None maps to empty dictionary
-        sql_args, _ = mock_sql_import_thread.call_args
-        assert sql_args[3] == {}
+        _, sql_kwargs = mock_sql_import_thread.call_args
+        assert sql_kwargs["import_params"] == {}
+        assert sql_kwargs["thread_event"].is_set()
 
         # verify callback_params=None maps to empty dictionary
         _, callback_kwargs = callback_spy.call_args

--- a/test/unit/http_transport_test.py
+++ b/test/unit/http_transport_test.py
@@ -1,3 +1,5 @@
+import threading
+from importlib import import_module
 from unittest.mock import (
     Mock,
     patch,
@@ -13,10 +15,13 @@ from pyexasol import (
 from pyexasol.http_transport import (
     ExaHttpThread,
     ExaHTTPTransportWrapper,
+    ExaSQLThread,
     ExportQuery,
     ImportQuery,
     SqlQuery,
 )
+
+http_transport_module = import_module("pyexasol.http_transport")
 
 
 @pytest.fixture
@@ -403,6 +408,103 @@ def export_callback(pipe, dst, **kwargs):
 
 def import_callback(pipe, src, **kwargs):
     raise Exception(ERROR_MESSAGE)
+
+
+class TestImportTransportThreadLifecycle:
+    @staticmethod
+    def test_sql_thread_signals_event_after_successful_query():
+        thread_event = threading.Event()
+
+        class SuccessfulSQLThread(ExaSQLThread):
+            def run_sql(self):
+                pass
+
+        http_thread = Mock()
+        thread = SuccessfulSQLThread(
+            connection=Mock(),
+            compression=False,
+            thread_event=thread_event,
+        )
+        thread.set_http_thread(http_thread)
+
+        thread.run()
+
+        assert thread.exc is None
+        assert thread_event.is_set()
+        http_thread.terminate.assert_not_called()
+
+    @staticmethod
+    def test_sql_thread_terminates_http_and_signals_event_on_failure():
+        thread_event = threading.Event()
+        expected_error = RuntimeError("SQL query failed")
+
+        class FailingSQLThread(ExaSQLThread):
+            def run_sql(self):
+                raise expected_error
+
+        http_thread = Mock()
+        thread = FailingSQLThread(
+            connection=Mock(),
+            compression=False,
+            thread_event=thread_event,
+        )
+        thread.set_http_thread(http_thread)
+
+        thread.run()
+
+        assert thread.exc is expected_error
+        assert thread_event.is_set()
+        http_thread.terminate.assert_called_once_with()
+
+    @staticmethod
+    def test_http_thread_closes_server_and_signals_event_after_success():
+        thread_event = threading.Event()
+        server = Mock(
+            total_clients=0,
+            is_terminated=False,
+            read_pipe=Mock(),
+            write_pipe=Mock(),
+        )
+        server.can_finish_get = Mock()
+
+        def handle_request():
+            server.total_clients = 1
+
+        server.handle_request.side_effect = handle_request
+
+        with patch.object(http_transport_module, "ExaTCPServer", return_value=server):
+            thread = ExaHttpThread(
+                "127.0.0.1", 8563, False, False, thread_event=thread_event
+            )
+            thread.run()
+
+        assert thread.exc is None
+        server.handle_request.assert_called_once_with()
+        server.server_close.assert_called_once_with()
+        assert thread_event.is_set()
+
+    @staticmethod
+    def test_http_thread_closes_server_and_signals_event_after_failure():
+        thread_event = threading.Event()
+        expected_error = BrokenPipeError("HTTP request failed")
+        server = Mock(
+            total_clients=0,
+            is_terminated=False,
+            read_pipe=Mock(),
+            write_pipe=Mock(),
+        )
+        server.can_finish_get = Mock()
+        server.handle_request.side_effect = expected_error
+
+        with patch.object(http_transport_module, "ExaTCPServer", return_value=server):
+            thread = ExaHttpThread(
+                "127.0.0.1", 8563, False, False, thread_event=thread_event
+            )
+            thread.run()
+
+        assert thread.exc is expected_error
+        server.server_close.assert_called_once_with()
+        assert thread_event.is_set()
 
 
 @pytest.fixture

--- a/test/unit/http_transport_test.py
+++ b/test/unit/http_transport_test.py
@@ -412,8 +412,8 @@ def import_callback(pipe, src, **kwargs):
 
 class TestImportTransportThreadLifecycle:
     @staticmethod
-    def test_sql_thread_signals_event_after_successful_query():
-        thread_event = threading.Event()
+    def test_sql_thread_signals_worker_finished_event_after_successful_query():
+        worker_finished_event = threading.Event()
 
         class SuccessfulSQLThread(ExaSQLThread):
             def run_sql(self):
@@ -423,19 +423,19 @@ class TestImportTransportThreadLifecycle:
         thread = SuccessfulSQLThread(
             connection=Mock(),
             compression=False,
-            thread_event=thread_event,
+            worker_finished_event=worker_finished_event,
         )
         thread.set_http_thread(http_thread)
 
         thread.run()
 
         assert thread.exc is None
-        assert thread_event.is_set()
+        assert worker_finished_event.is_set()
         http_thread.terminate.assert_not_called()
 
     @staticmethod
-    def test_sql_thread_terminates_http_and_signals_event_on_failure():
-        thread_event = threading.Event()
+    def test_sql_thread_terminates_http_and_signals_worker_finished_event_on_failure():
+        worker_finished_event = threading.Event()
         expected_error = RuntimeError("SQL query failed")
 
         class FailingSQLThread(ExaSQLThread):
@@ -446,19 +446,19 @@ class TestImportTransportThreadLifecycle:
         thread = FailingSQLThread(
             connection=Mock(),
             compression=False,
-            thread_event=thread_event,
+            worker_finished_event=worker_finished_event,
         )
         thread.set_http_thread(http_thread)
 
         thread.run()
 
         assert thread.exc is expected_error
-        assert thread_event.is_set()
+        assert worker_finished_event.is_set()
         http_thread.terminate.assert_called_once_with()
 
     @staticmethod
-    def test_http_thread_closes_server_and_signals_event_after_success():
-        thread_event = threading.Event()
+    def test_http_thread_closes_server_and_signals_worker_finished_event_after_success():
+        worker_finished_event = threading.Event()
         server = Mock(
             total_clients=0,
             is_terminated=False,
@@ -474,18 +474,22 @@ class TestImportTransportThreadLifecycle:
 
         with patch.object(http_transport_module, "ExaTCPServer", return_value=server):
             thread = ExaHttpThread(
-                "127.0.0.1", 8563, False, False, thread_event=thread_event
+                "127.0.0.1",
+                8563,
+                False,
+                False,
+                worker_finished_event=worker_finished_event,
             )
             thread.run()
 
         assert thread.exc is None
         server.handle_request.assert_called_once_with()
         server.server_close.assert_called_once_with()
-        assert thread_event.is_set()
+        assert worker_finished_event.is_set()
 
     @staticmethod
-    def test_http_thread_closes_server_and_signals_event_after_failure():
-        thread_event = threading.Event()
+    def test_http_thread_closes_server_and_signals_worker_finished_event_after_failure():
+        worker_finished_event = threading.Event()
         expected_error = BrokenPipeError("HTTP request failed")
         server = Mock(
             total_clients=0,
@@ -498,13 +502,17 @@ class TestImportTransportThreadLifecycle:
 
         with patch.object(http_transport_module, "ExaTCPServer", return_value=server):
             thread = ExaHttpThread(
-                "127.0.0.1", 8563, False, False, thread_event=thread_event
+                "127.0.0.1",
+                8563,
+                False,
+                False,
+                worker_finished_event=worker_finished_event,
             )
             thread.run()
 
         assert thread.exc is expected_error
         server.server_close.assert_called_once_with()
-        assert thread_event.is_set()
+        assert worker_finished_event.is_set()
 
 
 @pytest.fixture


### PR DESCRIPTION
closes #349 

Add threading event to coordinate end

When tried without a preceding `.join()`, it would hang indefinitely and would not reach the `.set()`.

Unit & integration test needed to be updated as mock was with join_with_exc, which is no longer used.

Add new integration test to mock DB license error.

# Checklist

Note: If any of the items in the checklist are not relevant to your PR, leave the box unchecked.

## For any Pull Request

Is the following correct:
* [x] the title of the Pull Request?
* [x] the title of the corresponding issue?
* [x] there are no other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line -->
* [x] that the issue which this Pull Request fixes ("Fixes...") is mentioned?

## When Changes Were Made

Did you:
* [x] update the changelog?
* [x] update the implementation?
* [x] check coverage and add tests: unit tests and, if relevant, integration tests?
* [ ] update the User Guide & other documentation? -> need to do
* [ ] resolve any failing CI criteria (incl. Sonar quality gate)?

## When Preparing a Release

Have you:
* [ ] thought about version number (major, minor, patch)?
* [ ] checked Exasol packages for updates and resolved open vulnerabilities, if easily possible?
